### PR TITLE
Added XCode Build Phase Script

### DIFF
--- a/Canvas.xcodeproj/project.pbxproj
+++ b/Canvas.xcodeproj/project.pbxproj
@@ -213,7 +213,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "WORKING_DIR=$(pwd)\n# temporarily switch to the JavaScript dir so we can run npm commands\ncd $SRCROOT\"/JavaScript\"\n# build the JavaScript bundle\nnpm run build\n# if non-zero exit code, exit and warn the user\nif [ $? -ne 0 ]; then\n        echo \"failure in 'Run Script' phase - building JS bundle\"\n        cd $WORKING_DIR\n        exit 1\nfi\n# go back to the working directory\ncd $WORKING_DIR\n";
+			shellScript = "WORKING_DIR=$(pwd)\n# temporarily switch to the JavaScript dir so we can run npm commands\ncd $SRCROOT\"/Javascript\"\n# build the JavaScript bundle\nnpm run build\n# if non-zero exit code, exit and warn the user\nif [ $? -ne 0 ]; then\n        echo \"failure in 'Run Script' phase - building JS bundle\"\n        cd $WORKING_DIR\n        exit 1\nfi\n# go back to the working directory\ncd $WORKING_DIR\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
This PR adds a shell script in the XCode Build Phase that runs `npm run build` before building the iOS project.

Rather than have two separate build processes (Xcode and Babel), this integrated Webpack's build process into Xcode's. Every time we build the app in Xcode, our build process uses Webpack to re-build the JS bundle. 

This way, the iOS app build will fail when the javascript code doesn't compile, and the error messages are surfaced onto XCode.